### PR TITLE
Added functionality to monitor recent files of app independednt from Okapi

### DIFF
--- a/OkapiLauncher.Core/Models/Apps/AvApp.cs
+++ b/OkapiLauncher.Core/Models/Apps/AvApp.cs
@@ -15,9 +15,11 @@ public record AvApp : IAvApp
     public string Path { get; }
     public string RootPath { get; }
     public string? LogFolderPath { get; }
+    public string AppDataPath { get; }
     public AvVersion Version { get; }
     public AvVersion? SecondaryVersion { get; }
     public string Name { get; }
+    public string NameWithVersion => $"{Name} {Version}";
     public string? Description { get; }
     public bool IsCustom => Description is not null;
     public string ProcessName { get; }
@@ -54,6 +56,7 @@ public record AvApp : IAvApp
         Description = description;
         RootPath = rootInstallationPath;
         LogFolderPath = GetLogFolderPath(this);
+        AppDataPath = GetAppDataPath(this);
     }
     private static string GetName(FileVersionInfo finfo, ProductType type)
     {
@@ -171,12 +174,17 @@ public record AvApp : IAvApp
 
     private static string? GetLogFolderPath(IAvApp app)
     {
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         return app.Type.Type switch
         {
-            AvType.Professional or AvType.Runtime => System.IO.Path.Join(localAppData, app.Brand.Name, System.IO.Path.GetFileName(app.RootPath), "Logs"),
-            AvType.DeepLearningGPU => System.IO.Path.Join(localAppData, app.Brand.Name, System.IO.Path.GetFileName(app.RootPath)),
+            AvType.Professional or AvType.Runtime => System.IO.Path.Join(GetAppDataPath(app), "Logs"),
+            AvType.DeepLearningGPU => GetAppDataPath(app),
             _ => null,
         };
+    }
+
+    private static string GetAppDataPath(IAvApp app)
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return System.IO.Path.Join(localAppData, app.Brand.Name, System.IO.Path.GetFileName(app.RootPath));
     }
 }

--- a/OkapiLauncher/App.xaml.cs
+++ b/OkapiLauncher/App.xaml.cs
@@ -99,6 +99,7 @@ public partial class App : Application
         services.AddSingleton<FileOpenerBroker>();
         services.AddSingleton<ICustomAppSourceService,CustomAppSourceService>();
         services.AddSingleton<IJumpListService,JumpListService>();
+        services.AddSingleton<IAppNativeRecentFilesService, AppNativeRecentFilesService>();
 
         services.AddSingleton<IProcessManagerService, ProcessManagerService>();
         // Views and ViewModels

--- a/OkapiLauncher/Contracts/Services/IAppNativeRecentFilesService.cs
+++ b/OkapiLauncher/Contracts/Services/IAppNativeRecentFilesService.cs
@@ -1,0 +1,33 @@
+﻿using OkapiLauncher.Core.Models.Apps;
+namespace OkapiLauncher.Contracts.Services
+{
+    public interface IAppNativeRecentFilesService
+    {
+        RecentAppFiles GetAppFiles(AvApp app);
+        IEnumerable<RecentAppFiles> GetAllAppsFiles();
+
+        record RecentAppFiles:IEquatable<RecentAppFiles>
+        {
+            public RecentAppFiles(AvApp app, IEnumerable<string> filepaths)
+            {
+                App = app;
+                _filepaths = filepaths.ToList();
+                int listHash = 1374;
+                foreach (var item in filepaths)
+                {
+                    listHash=HashCode.Combine(listHash, item);
+                }
+                Uniquifier = HashCode.Combine(app.Brand, app.Version, listHash);
+            }
+
+            public AvApp App { get; }
+            private List<string> _filepaths;
+            public IReadOnlyList<string> Filepaths => _filepaths.AsReadOnly();
+            private int Uniquifier { get; }
+            public override int GetHashCode()
+            {
+                return Uniquifier;
+            }
+        }
+    }
+}

--- a/OkapiLauncher/Properties/Resources.Designer.cs
+++ b/OkapiLauncher/Properties/Resources.Designer.cs
@@ -1188,7 +1188,7 @@ namespace OkapiLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to About.
+        ///   Looks up a localized string similar to _About.
         /// </summary>
         public static string ShellMenuItemViewsAboutPageHeader {
             get {
@@ -1197,7 +1197,16 @@ namespace OkapiLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Recently opened files.
+        ///   Looks up a localized string similar to Recent files per _App.
+        /// </summary>
+        public static string ShellMenuNativeRecentFiles {
+            get {
+                return ResourceManager.GetString("ShellMenuNativeRecentFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Recently opened files.
         /// </summary>
         public static string ShellMenuRecentFiles {
             get {

--- a/OkapiLauncher/Properties/Resources.Designer.cs
+++ b/OkapiLauncher/Properties/Resources.Designer.cs
@@ -963,6 +963,24 @@ namespace OkapiLauncher.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Clear missing recent files.
+        /// </summary>
+        public static string SettingsPageClearMissingRecentsButton {
+            get {
+                return ResourceManager.GetString("SettingsPageClearMissingRecentsButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Removes files that are no longer available from both recent files lists..
+        /// </summary>
+        public static string SettingsPageClearMissingRecentsTooltip {
+            get {
+                return ResourceManager.GetString("SettingsPageClearMissingRecentsTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use the default accent colors for Light and Dark themes.
         /// </summary>
         public static string SettingsPageCustomColorResetTooltip {
@@ -1206,11 +1224,29 @@ namespace OkapiLauncher.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Items that were recently opened by each available app (including those not coming from Okapi)..
+        /// </summary>
+        public static string ShellMenuNativeRecentFilesTooltip {
+            get {
+                return ResourceManager.GetString("ShellMenuNativeRecentFilesTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Recently opened files.
         /// </summary>
         public static string ShellMenuRecentFiles {
             get {
                 return ResourceManager.GetString("ShellMenuRecentFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Items that were recently open in Okapi Launcher..
+        /// </summary>
+        public static string ShellMenuRecentFilesTooltip {
+            get {
+                return ResourceManager.GetString("ShellMenuRecentFilesTooltip", resourceCulture);
             }
         }
         

--- a/OkapiLauncher/Properties/Resources.resx
+++ b/OkapiLauncher/Properties/Resources.resx
@@ -589,4 +589,16 @@ All trademarks, service marks, logos, and copyrights related to the applications
   <data name="ShellMenuNativeRecentFiles" xml:space="preserve">
     <value>Recent files per _App</value>
   </data>
+  <data name="SettingsPageClearMissingRecentsTooltip" xml:space="preserve">
+    <value>Removes files that are no longer available from both recent files lists.</value>
+  </data>
+  <data name="SettingsPageClearMissingRecentsButton" xml:space="preserve">
+    <value>Clear missing recent files</value>
+  </data>
+  <data name="ShellMenuRecentFilesTooltip" xml:space="preserve">
+    <value>Items that were recently open in Okapi Launcher.</value>
+  </data>
+  <data name="ShellMenuNativeRecentFilesTooltip" xml:space="preserve">
+    <value>Items that were recently opened by each available app (including those not coming from Okapi).</value>
+  </data>
 </root>

--- a/OkapiLauncher/Properties/Resources.resx
+++ b/OkapiLauncher/Properties/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ShellMenuItemViewsAboutPageHeader" xml:space="preserve">
-    <value>About</value>
+    <value>_About</value>
   </data>
   <data name="AboutPageTitle" xml:space="preserve">
     <value>About</value>
@@ -259,7 +259,7 @@
     <value>Copy the command-line string</value>
   </data>
   <data name="ShellMenuRecentFiles" xml:space="preserve">
-    <value>Recently opened files</value>
+    <value>_Recently opened files</value>
   </data>
   <data name="LaunchOptionsResetButton" xml:space="preserve">
     <value>Reset</value>
@@ -585,5 +585,8 @@ All trademarks, service marks, logos, and copyrights related to the applications
   </data>
   <data name="ProjectProductTypeDeepLearningLabel" xml:space="preserve">
     <value>Deep Learning model</value>
+  </data>
+  <data name="ShellMenuNativeRecentFiles" xml:space="preserve">
+    <value>Recent files per _App</value>
   </data>
 </root>

--- a/OkapiLauncher/Services/AppNativeRecentFilesService.cs
+++ b/OkapiLauncher/Services/AppNativeRecentFilesService.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using OkapiLauncher.Contracts.Services;
+using OkapiLauncher.Core.Models;
+using OkapiLauncher.Core.Models.Apps;
+
+namespace OkapiLauncher.Services
+{
+    public class AppNativeRecentFilesService : IAppNativeRecentFilesService
+    {
+        private class DateList
+        {
+            public DateTime ModificationDate { get; set; } = DateTime.MinValue;
+            public List<string> FilePaths { get; set; } = [];
+        }
+        public AppNativeRecentFilesService(IAvAppFacadeFactory avAppFacadeFactory)
+        {
+            _avAppFacadeFactory = avAppFacadeFactory;
+        }
+        private Dictionary<string, DateList> _modificationDates = new Dictionary<string, DateList>(StringComparer.OrdinalIgnoreCase);
+        private readonly IAvAppFacadeFactory _avAppFacadeFactory;
+
+        private IEnumerable<string> ReadAppRecentFiles(AvApp app)
+        {
+            if (app.Type != ProductType.Professional)
+            {
+                return [];
+            }
+            string settingsFilePath = Path.Join(app.AppDataPath, "settings.xml");
+            if (!_modificationDates.ContainsKey(settingsFilePath))
+            {
+                _modificationDates[settingsFilePath] = new();
+            }
+            var dateList = _modificationDates[settingsFilePath];
+            // skip checking if we checked no too long ago
+            if(DateTime.UtcNow - dateList.ModificationDate < TimeSpan.FromSeconds(20))
+            {
+                return dateList.FilePaths;
+            }
+            var modifDate = File.GetLastWriteTimeUtc(settingsFilePath);
+            if (dateList.ModificationDate < modifDate)
+            {
+                dateList.FilePaths.Clear();
+                using var reader = XmlReader.Create(settingsFilePath);
+                reader.ReadToFollowing("RecentFiles");
+                while (reader.ReadToFollowing("RecentFile"))
+                {
+                    reader.Read();
+                    dateList.FilePaths.Add(reader.ReadContentAsString());
+                }
+                dateList.ModificationDate = modifDate;
+            }
+            return dateList.FilePaths;
+        }
+        public IAppNativeRecentFilesService.RecentAppFiles GetAppFiles(AvApp app)
+        {
+            return new IAppNativeRecentFilesService.RecentAppFiles(app, ReadAppRecentFiles(app));
+        }
+
+        public IEnumerable<IAppNativeRecentFilesService.RecentAppFiles> GetAllAppsFiles()
+        {
+            return _avAppFacadeFactory.AvApps.Where(x=>x.Type.HasFlag(AvType.Professional)).Select(x=>GetAppFiles(x));
+        }
+    }
+}

--- a/OkapiLauncher/Styles/Button.xaml
+++ b/OkapiLauncher/Styles/Button.xaml
@@ -42,6 +42,8 @@
     <x:Static x:Key="IconGithub" Member="icons:MaterialIconKind.Github" />
     <x:Static x:Key="IconTurnOff" Member="icons:MaterialIconKind.CloseThick" />
     <x:Static x:Key="IconSettings" Member="icons:MaterialIconKind.Tools" />
+    <x:Static x:Key="IconRecentFiles" Member="icons:MaterialIconKind.History" />
+    <x:Static x:Key="IconRecentNativeFiles" Member="icons:MaterialIconKind.ClipboardTextClockOutline" />
     <x:Static x:Key="IconKill" Member="icons:MaterialIconKind.Power" />
     <x:Static x:Key="IconFocusOn" Member="icons:MaterialIconKind.TargetVariant" />
     <x:Static x:Key="IconKillAll" Member="icons:MaterialIconKind.Bomb" />

--- a/OkapiLauncher/ViewModels/ShellViewModel.cs
+++ b/OkapiLauncher/ViewModels/ShellViewModel.cs
@@ -26,6 +26,7 @@ public partial class ShellViewModel : ObservableRecipient, IRecipient<RecentFile
     private readonly INavigationService _navigationService;
     private readonly IRightPaneService _rightPaneService;
     private readonly IUpdateCheckService _updateCheckService;
+    private readonly IAppNativeRecentFilesService _appNativeRecentFilesService;
     private readonly Lazy<IWindowManagerService> _windowManagerService;
     private readonly IRecentlyOpenedFilesService _lastOpenedFilesService;
 
@@ -34,17 +35,22 @@ public partial class ShellViewModel : ObservableRecipient, IRecipient<RecentFile
                           IMessenger messenger,
                           IWindowManagerService windowManagerService,
                           IUpdateCheckService updateCheckService,
-
+                          IAppNativeRecentFilesService appNativeRecentFilesService,
                           IRecentlyOpenedFilesService lastOpenedFilesService) : base(messenger)
     {
         _navigationService = navigationService;
         _rightPaneService = rightPaneService;
         _updateCheckService = updateCheckService;
+        _appNativeRecentFilesService = appNativeRecentFilesService;
         _windowManagerService = new Lazy<IWindowManagerService>(windowManagerService);
         _lastOpenedFilesService = lastOpenedFilesService;
         RecentlyOpenedFiles = new ObservableCollection<RecentlyOpenedFileFacade>(_lastOpenedFilesService.GetLastOpenedFiles());
+        NativeRecentFiles = [];
         messenger.Register<RecentFilesChangedMessage>(this);
     }
+    [ObservableProperty]
+    private bool _isFileMenuOpen;
+    public ObservableCollection<IAppNativeRecentFilesService.RecentAppFiles> NativeRecentFiles { get; } = [];
     public ObservableCollection<RecentlyOpenedFileFacade> RecentlyOpenedFiles { get; }
     [RelayCommand]
     private void OnLoaded()
@@ -111,7 +117,7 @@ public partial class ShellViewModel : ObservableRecipient, IRecipient<RecentFile
         {
             Filter = "All Files (*.*)|*.*|Aurora Vision Files|*.avproj;*.avexe|FabImage Files|*.fiproj;*.fiexe|Project Files|*.avproj;*.fiproj|Runtime Files|*.avexe;*.fiexe",
             Multiselect = false,
-            DereferenceLinks= true,
+            DereferenceLinks = true,
         };
         var result = dialog.ShowDialog();
         if (result == true)
@@ -119,6 +125,11 @@ public partial class ShellViewModel : ObservableRecipient, IRecipient<RecentFile
             //_navigationService.NavigateTo(typeof(LauncherViewModel).FullName!);
             OpenProject(dialog.FileName);
         }
+    }
+    [RelayCommand()]
+    private void MenuOpenRecentNativeFile(string filepath)
+    {
+        OpenProject(filepath);
     }
     [RelayCommand()]
     private void MenuOpenRecentFile(RecentlyOpenedFileFacade file)
@@ -154,7 +165,7 @@ public partial class ShellViewModel : ObservableRecipient, IRecipient<RecentFile
             RecentlyOpenedFiles.Add(item);
         }
     }
-    
+
 
     [RelayCommand]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Can't static a relay command")]
@@ -166,5 +177,24 @@ public partial class ShellViewModel : ObservableRecipient, IRecipient<RecentFile
     private void KillAllChildren()
     {
         _windowManagerService.Value.CloseChildWindows();
+    }
+
+    partial void OnIsFileMenuOpenChanged(bool value)
+    {
+        var newFiles = _appNativeRecentFilesService.GetAllAppsFiles().ToArray();
+        if (NativeRecentFiles.Count == newFiles.Length)
+        {
+            var newHashes = newFiles.Select(x => x.GetHashCode());
+            var oldHashes = NativeRecentFiles.Select(x => x.GetHashCode());
+            if (oldHashes.SequenceEqual(newHashes))
+            {
+                return;
+            }
+        }
+        NativeRecentFiles.Clear();
+        foreach (var item in newFiles)
+        {
+            NativeRecentFiles.Add(item);
+        }
     }
 }

--- a/OkapiLauncher/Views/ShellWindow.xaml
+++ b/OkapiLauncher/Views/ShellWindow.xaml
@@ -162,7 +162,8 @@
                                 <MenuItem
                                     x:Name="FileMenu"
                                     AutomationProperties.Name="{Binding Header, RelativeSource={RelativeSource Self}}"
-                                    Header="{x:Static properties:Resources.ShellMenuFileHeader}">
+                                    Header="{x:Static properties:Resources.ShellMenuFileHeader}"
+                                    IsSubmenuOpen="{Binding IsFileMenuOpen}">
                                     <MenuItem
                                         AutomationProperties.Name="{Binding Header, RelativeSource={RelativeSource Self}}"
                                         Command="{Binding MenuFileOpenProjectCommand}"
@@ -198,6 +199,57 @@
                                                 </Style.Triggers>
                                             </Style>
                                         </MenuItem.ItemContainerStyle>
+                                    </MenuItem>
+                                    <MenuItem
+                                        AlternationCount="2"
+                                        AutomationProperties.Name="{Binding Header, RelativeSource={RelativeSource Self}}"
+                                        Header="{x:Static properties:Resources.ShellMenuNativeRecentFiles}"
+                                        ItemsSource="{Binding NativeRecentFiles}">
+                                        <MenuItem.ItemContainerStyle>
+                                            <Style BasedOn="{StaticResource MahApps.Styles.MenuItem}" TargetType="MenuItem">
+                                                <Setter Property="Header" Value="{Binding App.NameWithVersion}" />
+                                                <Setter Property="ItemsSource" Value="{Binding Filepaths}" />
+                                                <Setter Property="ItemContainerStyle">
+                                                    <Setter.Value>
+                                                        <Style BasedOn="{StaticResource MahApps.Styles.MenuItem}" TargetType="MenuItem">
+                                                            <Setter Property="Header" Value="{Binding ., Converter={StaticResource PathToFilenameConverter}, ConverterParameter=50}" />
+                                                            <Setter Property="Command" Value="{Binding DataContext.MenuOpenRecentNativeFileCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
+                                                            <Setter Property="CommandParameter" Value="{Binding}" />
+                                                            <Setter Property="ToolTip">
+                                                                <Setter.Value>
+                                                                    <StackPanel>
+                                                                        <TextBlock Text="{Binding}" />
+                                                                    </StackPanel>
+                                                                </Setter.Value>
+                                                            </Setter>
+                                                        </Style>
+                                                    </Setter.Value>
+                                                </Setter>
+                                            </Style>
+                                        </MenuItem.ItemContainerStyle>
+                                        <!--<MenuItem.ItemTemplate>
+                                            <HierarchicalDataTemplate ItemsSource="{Binding Filepaths}">
+                                                <TextBlock Text="{Binding App.Name}" />
+                                                <HierarchicalDataTemplate.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <MenuItem>
+                                                            <MenuItem.Style>
+                                                                <Style BasedOn="{StaticResource MahApps.Styles.MenuItem}" TargetType="MenuItem">
+                                                                    <Setter Property="Header" Value="{Binding ., Converter={StaticResource PathToFilenameConverter}, ConverterParameter=50}" />
+                                                                    <Setter Property="ToolTip">
+                                                                        <Setter.Value>
+                                                                            <StackPanel>
+                                                                                <TextBlock Text="{Binding}" />
+                                                                            </StackPanel>
+                                                                        </Setter.Value>
+                                                                    </Setter>
+                                                                </Style>
+                                                            </MenuItem.Style>
+                                                        </MenuItem>
+                                                    </DataTemplate>
+                                                </HierarchicalDataTemplate.ItemTemplate>
+                                            </HierarchicalDataTemplate>
+                                        </MenuItem.ItemTemplate>-->
                                     </MenuItem>
                                     <Separator />
                                     <MenuItem

--- a/OkapiLauncher/Views/ShellWindow.xaml
+++ b/OkapiLauncher/Views/ShellWindow.xaml
@@ -173,11 +173,16 @@
                                             <mdicons:MaterialIcon Kind="FolderOpen" />
                                         </MenuItem.Icon>
                                     </MenuItem>
+                                    <Separator />
                                     <MenuItem
                                         AlternationCount="2"
                                         AutomationProperties.Name="{Binding Header, RelativeSource={RelativeSource Self}}"
                                         Header="{x:Static properties:Resources.ShellMenuRecentFiles}"
+                                        ToolTip="{x:Static properties:Resources.ShellMenuRecentFilesTooltip}"
                                         ItemsSource="{Binding RecentlyOpenedFiles}">
+                                        <MenuItem.Icon>
+                                            <mdicons:MaterialIcon Kind="{StaticResource IconRecentFiles}" />
+                                        </MenuItem.Icon>
                                         <MenuItem.ItemContainerStyle>
                                             <Style BasedOn="{StaticResource MahApps.Styles.MenuItem}" TargetType="MenuItem">
                                                 <Setter Property="Header" Value="{Binding FilePath, Converter={StaticResource PathToFilenameConverter}, ConverterParameter=50}" />
@@ -204,7 +209,11 @@
                                         AlternationCount="2"
                                         AutomationProperties.Name="{Binding Header, RelativeSource={RelativeSource Self}}"
                                         Header="{x:Static properties:Resources.ShellMenuNativeRecentFiles}"
+                                        ToolTip="{x:Static properties:Resources.ShellMenuNativeRecentFilesTooltip}"
                                         ItemsSource="{Binding NativeRecentFiles}">
+                                        <MenuItem.Icon>
+                                            <mdicons:MaterialIcon Kind="{StaticResource IconRecentNativeFiles}" />
+                                        </MenuItem.Icon>
                                         <MenuItem.ItemContainerStyle>
                                             <Style BasedOn="{StaticResource MahApps.Styles.MenuItem}" TargetType="MenuItem">
                                                 <Setter Property="Header" Value="{Binding App.NameWithVersion}" />


### PR DESCRIPTION
The app can now read recent files of studio applications and show them in a dedicated File submenu.
Those can of course also be loaded in Okapi.